### PR TITLE
Making logging level an env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Visit [Beep Boop](https://beepboophq.com/docs/article/overview) to get the scoop
 
 ### Run locally
 Install dependencies ([virtualenv](http://virtualenv.readthedocs.org/en/latest/) is recommended.)
+
 	pip install -r requirements.txt
 	export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ Visit [Beep Boop](https://beepboophq.com/docs/article/overview) to get the scoop
 ### Run locally
 Install dependencies ([virtualenv](http://virtualenv.readthedocs.org/en/latest/) is recommended.)
 
-  `pip install -r requirements.txt`
-
-	`export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py`
+  pip install -r requirements.txt
+  export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py
 
 Things are looking good if the console prints something like:
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ Visit [Beep Boop](https://beepboophq.com/docs/article/overview) to get the scoop
 
 ### Run locally
 Install dependencies ([virtualenv](http://virtualenv.readthedocs.org/en/latest/) is recommended.)
-
-  pip install -r requirements.txt
-  export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py
+	pip install -r requirements.txt
+	export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py
 
 Things are looking good if the console prints something like:
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ Visit [Beep Boop](https://beepboophq.com/docs/article/overview) to get the scoop
 ### Run locally
 Install dependencies ([virtualenv](http://virtualenv.readthedocs.org/en/latest/) is recommended.)
 
-  pip install -r requirements.txt
-	export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py
+  `pip install -r requirements.txt`
+
+	`export SLACK_TOKEN=<YOUR SLACK TOKEN>; python rtmbot.py`
 
 Things are looking good if the console prints something like:
 
 	Connected <your bot name> to <your slack team> team at https://<your slack team>.slack.com.
 
-If you want additional logging and debugging info, prepend `export DEBUG=True; ` to the `python rtmbot.py` command.
+If you want change the logging level, prepend `export LOG_LEVEL=<your level>; ` to the `python rtmbot.py` command.
 
 ### Run locally in Docker
 	docker build -t starter-python-bot .

--- a/bot.yml
+++ b/bot.yml
@@ -3,10 +3,10 @@ description: A simple Python bot sample for Beep Boop
 avatar: images/avatar.png
 background: images/background.png
 config:
-  - name: OPTION
-    friendly_name: Some Unnecessary Option
-    info: This is an unnecessary option
-    default: the default value
+  - name: LOG_LEVEL
+    friendly_name: Severity level to show for logging.
+    info: See https://docs.python.org/2/library/logging.html#levels
+    default: DEBUG
   - name: SECRET
     friendly_name: Shhhh
     info: This is an secret option

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -17,7 +17,7 @@ from slackclient import SlackClient
 
 def dbg(debug_string):
     if debug:
-        logging.info(debug_string)
+        logging.debug(debug_string)
 
 class RtmBot(object):
     def __init__(self, token):
@@ -29,10 +29,10 @@ class RtmBot(object):
         """Convenience method that creates Server instance"""
         self.slack_client = SlackClient(self.token)
         self.slack_client.rtm_connect()
-        print "Connected {} to {} team at https://{}.slack.com".format(
+        logging.info("Connected {} to {} team at https://{}.slack.com".format(
             self.slack_client.server.username,
             self.slack_client.server.login_data['team']['name'],
-            self.slack_client.server.domain)
+            self.slack_client.server.domain))
     def start(self):
         self.connect()
         self.load_plugins()
@@ -110,7 +110,7 @@ class Plugin(object):
         if 'crontable' in dir(self.module):
             for interval, function in self.module.crontable:
                 self.jobs.append(Job(interval, eval("self.module."+function)))
-            logging.info(self.module.crontable)
+            logging.debug("crontable: {}".format(self.module.crontable))
             self.module.crontable = []
         else:
             self.module.crontable = []
@@ -137,7 +137,7 @@ class Plugin(object):
         while True:
             if 'outputs' in dir(self.module):
                 if len(self.module.outputs) > 0:
-                    logging.info("output from {}".format(self.module))
+                    logging.debug("output from {}".format(self.module))
                     output.append(self.module.outputs.pop(0))
                 else:
                     break
@@ -189,9 +189,12 @@ if __name__ == "__main__":
                                 directory
                                 ))
 
-    debug = os.getenv("DEBUG", "False")
-    if debug == "True":
-        logging.basicConfig(level=logging.DEBUG)
+    log_level = os.getenv("LOG_LEVEL", "DEBUG")
+    logging.basicConfig(format='%(asctime)s - %(levelname)s: %(message)s', level=log_level)
+    debug = False
+    if log_level == "DEBUG":
+        debug = True
+
     slack_token = os.getenv("SLACK_TOKEN", "")
     logging.info("token: {}".format(slack_token))
     if slack_token == "":


### PR DESCRIPTION
Changed the env var that controls logging to pass in the explicit level that is desired, defaulted to DEBUG for the bot.yml file.  Also changed the formatting of the logging to print the level and the date.
### How to Test

Run it locally and change the LOG_LEVEL from DEBUG to INFO to see different levels of logging.
`export SLACK_TOKEN=xoxb-18316206129-DnZvMWcZPc53nx0NS5Y7S8S5`
`export LOG_LEVEL=DEBUG; python rtmbot.py`
