### PR TITLE
Implemented pybot attachment command, through api_call.

### DIFF
--- a/plugins/starter.py
+++ b/plugins/starter.py
@@ -4,6 +4,7 @@ import random
 import logging
 crontable = []
 outputs = []
+attachments = []
 typing_sleep = 0
 
 greetings = ['Hi friend!', 'Hello there.', 'Howdy!', 'Wazzzup!!!', 'Hi!', 'Hey.']
@@ -23,21 +24,39 @@ p_bot_help = re.compile("pybot[\s]*help")
 
 def process_message(data):
     logging.debug("process_message:data: {}".format(data))
+
     if p_bot_hi.match(data['text']):
         outputs.append([data['channel'], "{}".format(random.choice(greetings))])
+
     elif p_bot_joke.match(data['text']):
         outputs.append([data['channel'], "Why did the python cross the road?"])
         outputs.append([data['channel'], "__typing__", 5])
         outputs.append([data['channel'], "To eat the chicken on the other side! :laughing:"])
+
     elif p_bot_attach.match(data['text']):
-        outputs.append([data['channel'], "Sorry, I can't do this yet. :disappointed:"])
+        txt = "Beep Beep Boop is a ridiculously simple hosting platform for your Slackbots."
+        attachments.append([data['channel'], txt, build_demo_attachment(txt)])
+
     elif p_bot_help.match(data['text']):
         outputs.append([data['channel'], "{}".format(help_text)])
+
     elif data['text'].startswith("pybot"):
         outputs.append([data['channel'], "I'm sorry, I don't know how to: `{}`".format(data['text'])])
+
     elif data['channel'].startswith("D"):  # direct message channel to the bot
         outputs.append([data['channel'], "Hello, I'm the BeepBoop python starter bot.\n{}".format(help_text)])
 
 def process_mention(data):
     logging.debug("process_mention:data: {}".format(data))
     outputs.append([data['channel'], "You really do care about me. :heart:"])
+
+def build_demo_attachment(txt):
+    return {
+        "pretext" : "We bring bots to life. :sunglasses: :thumbsup:",
+		"title" : "Host, deploy and share your bot in seconds.",
+		"title_link" : "https://beepboophq.com/",
+		"text" : txt,
+		"fallback" : txt,
+		"image_url" : "https://storage.googleapis.com/beepboophq/_assets/bot-1.22f6fb.png",
+		"color" : "#7CD197",
+    }


### PR DESCRIPTION
#### What's this PR do?

Using the api_call("chat.PostMessage", ...) to provide a way to add attachments to messages when the bot is given the `pybot attachment` command.
#### Where should the reviewer start?

Had to create an attachments[] in the starter plugin which is how the data is communicated back to the RtmBot class.
#### How should this be manually tested?

`export SLACK_TOKEN=xoxb-18316206129-DnZvMWcZPc53nx0NS5Y7S8S5; ./rtmbot.py`

Then login to RobotsAndPencils team in Slack, and direct message the `Slacks PythonBot` user.  Try the `pybot attachment` command and verify you see a message with image attachments.
#### Any background context you want to provide?

Took awhile to figure out how to make api_call correctly, wasn't well documented with examples in python-slack-client.
#### Screenshots (if appropriate)

<img width="690" alt="pybotattachment" src="https://cloud.githubusercontent.com/assets/1517743/12487246/94496196-c023-11e5-9f61-6561a765d1ab.png">
