### PR TITLE
Fixing non-user messages bug (issues #10, #11)

### DIFF
--- a/bot/event_handler.py
+++ b/bot/event_handler.py
@@ -33,8 +33,8 @@ class RtmEventHandler(object):
             pass
 
     def _handle_message(self, event):
-        # Filter out messages from the bot itself
-        if not self.clients.is_message_from_me(event['user']):
+        # Filter out messages from the bot itself, and from non-users (eg. webhooks)
+        if ('user' in event) and (not self.clients.is_message_from_me(event['user'])):
 
             msg_txt = event['text']
 


### PR DESCRIPTION
This is a small change to one line, that fixes a **key error** exception that is crashing the bot when it receives certain messages. See issue #10 and #11.
