### PR TITLE
Better handling of unicode strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+.idea/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+.DS_Store
+plot.png

--- a/bot/event_handler.py
+++ b/bot/event_handler.py
@@ -48,5 +48,7 @@ class RtmEventHandler(object):
                     self.msg_writer.write_joke(event['channel'])
                 elif 'attachment' in msg_txt:
                     self.msg_writer.demo_attachment(event['channel'])
+                elif 'echo' in msg_txt:
+                    self.msg_writer.send_message(event['channel'], msg_txt)
                 else:
                     self.msg_writer.write_prompt(event['channel'])

--- a/bot/messenger.py
+++ b/bot/messenger.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import logging
 import random
 
@@ -12,9 +14,9 @@ class Messenger(object):
         # in the case of Group and Private channels, RTM channel payload is a complex dictionary
         if isinstance(channel_id, dict):
             channel_id = channel_id['id']
-        logger.debug('Sending msg: {} to channel: {}'.format(msg, channel_id))
+        logger.debug('Sending msg: %s to channel: %s' % (msg, channel_id))
         channel = self.clients.rtm.server.channels.find(channel_id)
-        channel.send_message("{}".format(msg.encode('ascii', 'ignore')))
+        channel.send_message(msg)
 
     def write_help_message(self, channel_id):
         bot_uid = self.clients.bot_user_id()


### PR DESCRIPTION
#### What's this PR do?

Changes the formatting of the debugging string and sending the raw message string to the slack client to fix a UnicodeError bug that was brought up in the Beep Boop slack channel.  Also provides an echo handler that allows us to test by having the bot return back what the user messaged to them.  And last, added a .gitignore file.
#### Where should the reviewer start?

bot/messenger.py
#### How should this be manually tested?

Run the bot locally:
export SLACK_TOKEN=<bot_token>; python ./bot/app.py

Open DM with your starter bot and say:
`@<bots name> echo • What?`

Verify that the bot returns back the same message including the unicode `•` character.
#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1517743/18532162/8da34cce-7a97-11e6-990e-a11151b37723.png)
