### PR TITLE
Automatically accept direct messages

### DIFF
--- a/bot/event_handler.py
+++ b/bot/event_handler.py
@@ -59,6 +59,4 @@ class RtmEventHandler(object):
         Args:
             channel (str): Channel in which a message was received
         """
-        if channel.startswith('D'):
-            return True
-        return False
+        return channel.startswith('D')

--- a/bot/event_handler.py
+++ b/bot/event_handler.py
@@ -38,7 +38,7 @@ class RtmEventHandler(object):
 
             msg_txt = event['text']
 
-            if self.clients.is_bot_mention(msg_txt):
+            if self.clients.is_bot_mention(msg_txt) or self._is_direct_message(event['channel']):
                 # e.g. user typed: "@pybot tell me a joke!"
                 if 'help' in msg_txt:
                     self.msg_writer.write_help_message(event['channel'])
@@ -52,3 +52,13 @@ class RtmEventHandler(object):
                     self.msg_writer.send_message(event['channel'], msg_txt)
                 else:
                     self.msg_writer.write_prompt(event['channel'])
+
+    def _is_direct_message(self, channel):
+        """Check if channel is a direct message channel
+
+        Args:
+            channel (str): Channel in which a message was received
+        """
+        if channel.startswith('D'):
+            return True
+        return False


### PR DESCRIPTION
If you’re in a private channel, there’s no need to prefix every message with `@bot`.

Checks the channel in which a message was received to see if it was a DM channel. If so, handles the message equivalent to there being an @mention